### PR TITLE
Returns empty text instead of Encrypted - Fixed

### DIFF
--- a/EntityFramework.Core.EncryptDBColumn/Util/GenerateEncryptionProvider.cs
+++ b/EntityFramework.Core.EncryptDBColumn/Util/GenerateEncryptionProvider.cs
@@ -31,8 +31,8 @@ namespace EntityFrameworkCore.EncryptColumn.Util
                         using (StreamWriter streamWriter = new StreamWriter((Stream)cryptoStream))
                         {
                             streamWriter.Write(dataToEncrypt);
-                            array = memoryStream.ToArray();
                         }
+                        array = memoryStream.ToArray();
                     }
                 }
             }


### PR DESCRIPTION
Tested with Connection on SqlServer version 5.0.9.
Instead of Encrypted Text, saves blank text in database.